### PR TITLE
gpgstore: get: return decrypted data

### DIFF
--- a/gpgstore.py
+++ b/gpgstore.py
@@ -56,7 +56,7 @@ class GpgStore(object):
             log.error("decryption failed, %s: %s", res.status, path)
             raise OSError(errno.EIO)
         log.debug('decrypted %s' % path)
-        return data
+        return res.data
 
     def delete(self, path):
         os.remove(self.encroot + '/' + path)


### PR DESCRIPTION
Since c6a8ce7daa7545b6bc19d279e4ff8ab746c06eb6 ("GPG does zlib
compression by default") the encrypted data was returned which makes
gpgfs unusable.
